### PR TITLE
Fix URL mappings for forgot and reset password flows

### DIFF
--- a/src/main/java/com/example/tourify_system_be/controller/PageController.java
+++ b/src/main/java/com/example/tourify_system_be/controller/PageController.java
@@ -22,7 +22,7 @@ public class PageController {
         return "landing";
     }
 
-    @GetMapping("forgot_password")
+    @GetMapping("/forgot_password")
     public String forgotPasswordPage() {
         return "forgot_password";
     }

--- a/src/main/resources/static/js/reset_password.js
+++ b/src/main/resources/static/js/reset_password.js
@@ -47,7 +47,7 @@ document.addEventListener("DOMContentLoaded", function () {
             if (response.ok) {
                 alert("Đặt lại mật khẩu thành công. Bạn có thể đăng nhập lại.");
                 // Ví dụ: chuyển đến trang đăng nhập
-                window.location.href = "/login";
+                window.location.href = "/tourify/login";
             } else {
                 const error = await response.json();
                 alert("Lỗi: " + (error.message || "Không thể đặt lại mật khẩu."));


### PR DESCRIPTION
- Corrected `@GetMapping` in `PageController` to include leading slash for consistency.
- Updated redirect path in `reset_password.js` to `/tourify/login`.